### PR TITLE
feat: add support for local Ollama instance

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -1,4 +1,13 @@
+# Default settings to use OpenAI
+BASE_URL=
 OPENAI_API_KEY=
+DEFAULT_MODEL=gpt-4-turbo
+
+# Uncomment these settings to use local Ollama server with the compatible OpenAI API endpoint
+# BASE_URL='http://localhost:11434/v1'
+# OPENAI_API_KEY=ollama
+# DEFAULT_MODEL=llama3:latest
+
 CHATGPT_MODEL=gpt-4-turbo
 MEMORY_MODEL=gpt-4-turbo
 OPENAI_EMBEDDING_MODEL=text-embedding-ada-002

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Read more [on our blog](https://www.goodai.com/introducing-charlie-mnemonic/)
 - User data management including import/export of data. (WIP)
 - Extensible with additional modules (addons).
 - WebSocket support for real-time communication.
+- Use local Ollama instance instead of OpenAI.
 
 ## Installation
 
@@ -24,7 +25,7 @@ Read more [on our blog](https://www.goodai.com/introducing-charlie-mnemonic/)
 
 - How to install, develop and run Charlie Mnemonic [manually](docs/DEV-SETUP.md)
 
-
+- To use Ollama please look at [Ollama](https://ollama.com/) to download and setup the Ollama server.
 
 ## Links
 

--- a/config.py
+++ b/config.py
@@ -1,12 +1,16 @@
 import os
 from typing import Dict, Optional
 
+from dotenv import load_dotenv
+
 from simple_utils import get_root
+
+load_dotenv()
 
 api_keys: Dict[str, Optional[str]] = {}
 
 default_params = {
-    "model": "gpt-4-turbo",
+    "model": os.getenv("DEFAULT_MODEL", "gpt-4-turbo"),
     "temperature": 0.3,
     "max_tokens": 1000,
 }

--- a/llmcalls.py
+++ b/llmcalls.py
@@ -21,7 +21,9 @@ class OpenAIResponser:
     def __init__(self, api_key: str, default_params=None):
         if default_params is None:
             default_params = {}
-        self.client = AsyncOpenAI(api_key=api_key)
+            
+        base_url = os.getenv("BASE_URL", None)
+        self.client = AsyncOpenAI(base_url=base_url, api_key=api_key)
         self.default_params = default_params
         self.addons = self.load_addons()
 


### PR DESCRIPTION
This PR introduces the ability to use the local Ollama server as an alternative to OpenAI's API for language model calls. The following changes have been made:

### Changes

- Updated the `.env_sample` file with new environment variables for configuring the Ollama server URL and API key.
- Modified the `config.py` file to load environment variables from the `.env` file.
- Updated `llmcalls.py` to use the `BASE_URL` environment variable when instantiating the `AsyncOpenAI` client, allowing it to connect to a local Ollama instance.
- Added instructions to the `README.md` file on how to set up and use the local Ollama instance.

### Benefits

- Provides an alternative to using OpenAI's API, which may be beneficial for users who prefer to run a local instance for privacy, cost, or other reasons.
- Allows for easier testing and development by running a local Ollama instance without relying on external services.
- Improves flexibility and extensibility by supporting multiple language model providers.

### Testing

- Manually tested the application with both OpenAI and a local Ollama instance to ensure functionality.
- **Not tested against Docker**

### Documentation

- Updated the project documentation to reflect the new Ollama support and configuration options.

### Notes

- This change is backward-compatible, and the application will continue to use OpenAI by default if no Ollama configuration is provided.
- Users will need to set up and run their own Ollama instance to take advantage of this feature.

Please review the changes and provide feedback. If everything looks good, we can merge this PR and proceed with the next steps.
