### PR TITLE
Refactor all docker-compose command

### DIFF
--- a/docs/DEV-SETUP.md
+++ b/docs/DEV-SETUP.md
@@ -74,7 +74,7 @@ respectively.
 If you are using docker, you can just start the database with docker-compose:
 
 ```bash
-docker-compose up -d psdb
+docker compose up -d psdb
 ```
 
 In that case, you can use the following connection string:

--- a/release/purge.bat
+++ b/release/purge.bat
@@ -7,7 +7,7 @@ echo Warning, this will purge all Charlie Mnemonic data, are you sure you want t
 pause
 
 
-docker-compose --project-name charlie-mnemonic-windows down
+docker compose --project-name charlie-mnemonic-windows down
 docker volume rm charlie-mnemonic-windows_postgres-data
 
 if exist "%CHARLIE_MNEMONIC_USER_DIR%" (

--- a/release/start.bat
+++ b/release/start.bat
@@ -25,14 +25,14 @@ if not exist .env (
 )
 
 echo Stopping current Charlie Mnemonic containers...
-docker-compose --project-name charlie-mnemonic-windows down
+docker compose --project-name charlie-mnemonic-windows down
 
 echo Pulling the latest images...
-docker-compose --project-name charlie-mnemonic-windows pull
+docker compose --project-name charlie-mnemonic-windows pull
 
 echo Starting Charlie Mnemonic using Docker Compose...
 echo First run takes a while
-docker-compose --project-name charlie-mnemonic-windows up --detach
+docker compose --project-name charlie-mnemonic-windows up --detach
 
 rem Check the error level of the docker-compose command
 if not %ERRORLEVEL% == 0 (
@@ -48,7 +48,7 @@ if %errorlevel%==0 (
     timeout /t 1 /nobreak >nul
     start %URL%
     docker logs -f charlie-mnemonic
-    docker-compose --project-name charlie-mnemonic-windows down
+    docker compose --project-name charlie-mnemonic-windows down
 ) else (
     echo Not available yet. Retrying in 5 seconds...
     timeout /t 5 /nobreak >nul

--- a/release/stop.bat
+++ b/release/stop.bat
@@ -5,6 +5,6 @@ set HOME=%USERPROFILE%
 set CHARLIE_MNEMONIC_USER_DIR=%HOME%\AppData\Roaming\charlie-mnemonic\users
 
 echo Stopping Charlie Mnemonic using Docker Compose...
-docker-compose --project-name charlie-mnemonic-windows down
+docker compose --project-name charlie-mnemonic-windows down
 
 endlocal

--- a/release/uninstall.bat
+++ b/release/uninstall.bat
@@ -3,7 +3,7 @@ setlocal
 set HOME=%USERPROFILE%
 
 echo Stopping and removing Charlie Mnemonic containers...
-docker-compose down
+docker compose down
 
 echo Removing Docker images for Charlie Mnemonic...
 docker rmi goodaidev/charlie-mnemonic:latest

--- a/release/update.bat
+++ b/release/update.bat
@@ -3,10 +3,10 @@ setlocal
 set HOME=%USERPROFILE%
 
 echo Stopping current Charlie Mnemonic containers...
-docker-compose down
+docker compose down
 
 echo Pulling the latest images...
-docker-compose pull
+docker compose pull
 
 echo Containers have been updated. Please start the application again using start.bat.
 

--- a/start_local.bat
+++ b/start_local.bat
@@ -100,11 +100,11 @@ echo Removing any existing containers with the same names
 docker rm -f charlie-mnemonic psdb charlie-mnemonic-python-env 2>nul
 
 echo Stopping any existing Docker containers
-docker-compose down 2>nul
+docker compose down 2>nul
 
 echo Starting Charlie Mnemonic using Docker Compose...
 echo First run takes a while
-docker-compose up --build -d
+docker compose up --build -d
 
 if errorlevel 1 (
     echo Docker Compose up command failed.
@@ -129,7 +129,7 @@ if !ERRORLEVEL!==0 (
     timeout /t 1 /nobreak >nul
     start %URL%
     docker logs -f charlie-mnemonic
-    docker-compose down
+    docker compose down
 ) else (
     echo Not available yet. Retrying in 10 seconds...
     timeout /t 10 /nobreak >nul

--- a/start_local.sh
+++ b/start_local.sh
@@ -19,7 +19,7 @@ docker info || { echo "Docker daemon is not running. Please start Docker before 
 
 # Ensure that Docker Compose is not already running using the same names
 echo "Stopping existing Docker containers to prevent name conflicts..."
-docker-compose down || true
+docker compose down || true
 
 # Attempt to remove containers explicitly, suppressing errors for non-existing containers
 docker rm -f charlie-mnemonic psdb charlie-mnemonic-python-env || true
@@ -32,7 +32,7 @@ fi
 
 # Start the application using Docker Compose
 echo "Starting Charlie Mnemonic using Docker Compose. First run may take a while..."
-docker-compose up --build || { echo "Docker Compose failed with error level $?."; exit 1; }
+docker compose up --build || { echo "Docker Compose failed with error level $?."; exit 1; }
 
 # Monitoring loop to check if the application is running
 while true; do
@@ -42,7 +42,7 @@ while true; do
         sleep 1
         xdg-open "$URL"
         docker logs -f charlie-mnemonic
-        docker-compose down
+        docker compose down
         exit 0
     else
         echo "Charlie Mnemonic is not available yet. Retrying in 5 seconds..."


### PR DESCRIPTION
Reopen another one , fix small stype in PR #38 to avoid populating the tree with minor commit.


**Original PR content**

docker-compose cli command belong to CLI v1, which is already deprecated since last year and new installation already shown that docker-compose command will no longer work. Aside from the traditional docker-compose.yaml filename, the bash scripts should refer to the lastest CLI version

Reference
https://docs.docker.com/compose/releases/migrate/ 
